### PR TITLE
Add AssemblyInfo.ProductVersion

### DIFF
--- a/AssemblyVersionLoader/AssemblyVersionLoader.ps1
+++ b/AssemblyVersionLoader/AssemblyVersionLoader.ps1
@@ -22,6 +22,7 @@ function SetAssemblyVariables($file)
     Write-Host ("Loaded assembly file '" + $assemblyName + "'")
 	$assemblyVersion = [Version](([Reflection.AssemblyName]$assemblyName)).Version
   	$fileVersion = [Version]([System.Diagnostics.FileVersionInfo]::GetVersionInfo($file)).FileVersion
+	$productVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($file).ProductVersion
     
     $propertyName = "AssemblyInfo"
     #SetBuildVariable "$prefix$propertyName.Description" $assemblyName.Description
@@ -44,7 +45,8 @@ function SetAssemblyVariables($file)
     SetBuildVariable "$prefix$propertyName.Build" $fileVersion.Build
     SetBuildVariable "$prefix$propertyName.Revision" $fileVersion.Revision
 
-
+	$propertyName = "AssemblyInfo.ProductVersion"
+	SetBuildVariable "$prefix$propertyName" $productVersion
 }
 
 

--- a/AssemblyVersionLoader/AssemblyVersionLoader.ps1
+++ b/AssemblyVersionLoader/AssemblyVersionLoader.ps1
@@ -1,6 +1,6 @@
-﻿Param (
+Param (
     [string]$sourceFileName = "",
-	[string]$variablesPrefix = ""
+    [string]$variablesPrefix = ""
 )
   
 ## Load for $/Development/DwCms.Base/bin/release/DwCms.Base.dll
@@ -11,18 +11,18 @@
 
 function SetBuildVariable([string]$varName, [string]$varValue)
 {
-	Write-Host ("Setting variable " + $variablesPrefix + $varName + " to '" + $varValue + "'")
-	Write-Output ("##vso[task.setvariable variable=" + $variablesPrefix + $varName + ";]" +  $varValue )
+    Write-Host ("Setting variable " + $variablesPrefix + $varName + " to '" + $varValue + "'")
+    Write-Output ("##vso[task.setvariable variable=" + $variablesPrefix + $varName + ";]" +  $varValue )
 }
 
 function SetAssemblyVariables($file)
 {
-	Write-Host ("Loading assembly file '" + $file + "'...")
+    Write-Host ("Loading assembly file '" + $file + "'...")
     $assemblyName = [System.Reflection.AssemblyName]([System.Reflection.AssemblyName]::GetAssemblyName($file))
     Write-Host ("Loaded assembly file '" + $assemblyName + "'")
-	$assemblyVersion = [Version](([Reflection.AssemblyName]$assemblyName)).Version
-  	$fileVersion = [Version]([System.Diagnostics.FileVersionInfo]::GetVersionInfo($file)).FileVersion
-	$productVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($file).ProductVersion
+    $assemblyVersion = [Version](([Reflection.AssemblyName]$assemblyName)).Version
+    $fileVersion = [Version]([System.Diagnostics.FileVersionInfo]::GetVersionInfo($file)).FileVersion
+    $productVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($file).ProductVersion
     
     $propertyName = "AssemblyInfo"
     #SetBuildVariable "$prefix$propertyName.Description" $assemblyName.Description
@@ -45,8 +45,8 @@ function SetAssemblyVariables($file)
     SetBuildVariable "$prefix$propertyName.Build" $fileVersion.Build
     SetBuildVariable "$prefix$propertyName.Revision" $fileVersion.Revision
 
-	$propertyName = "AssemblyInfo.ProductVersion"
-	SetBuildVariable "$prefix$propertyName" $productVersion
+    $propertyName = "AssemblyInfo.ProductVersion"
+    SetBuildVariable "$prefix$propertyName" $productVersion
 }
 
 

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ $(AssemblyInfo.AssemblyVersion.Major)
 | AssemblyInfo.FileVersion.Minor | Minor digit from the file version. |
 | AssemblyInfo.FileVersion.Build | Build digit from the file version. |
 | AssemblyInfo.FileVersion.Revision | Revision digit from the file version. |
+| AssemlbyInfo.ProductVersion | Informational version from the assembly |
 
 # Credits
 This extension was created out of inspiration of (and derived from):


### PR DESCRIPTION
Along with pre-release nuget packages we also create pre-release base packages of our software. The version string is part of the created zip file. Added $AssemblyInfo.ProductVersion as build variable to be able to access AssemblyInformationalVersion from the assembly.